### PR TITLE
Support APNS Variable Token Length

### DIFF
--- a/push_notifications/api/rest_framework.py
+++ b/push_notifications/api/rest_framework.py
@@ -49,7 +49,7 @@ class APNSDeviceSerializer(ModelSerializer):
 		# iOS device tokens are 256-bit hexadecimal (64 characters). In 2016 Apple is increasing
 		# iOS device tokens to 100 bytes hexadecimal (200 characters).
 
-		if hex_re.match(value) is None or len(value) not in (64, 200):
+		if hex_re.match(value) is None:
 			raise ValidationError("Registration ID (device token) is invalid")
 
 		return value

--- a/push_notifications/api/rest_framework.py
+++ b/push_notifications/api/rest_framework.py
@@ -46,10 +46,12 @@ class APNSDeviceSerializer(ModelSerializer):
 		model = APNSDevice
 
 	def validate_registration_id(self, value):
-		# iOS device tokens are 256-bit hexadecimal (64 characters). In 2016 Apple is increasing
-		# iOS device tokens to 100 bytes hexadecimal (200 characters).
+		# According to Apple Docs "APNs device tokens are of variable length. Do not hard-code their size."
+		# Source: https://developer.apple.com/documentation/uikit/uiapplicationdelegate/1622958-application
+		# However, we need to make sure that token length is not greater than 200 because this is the max_length
+		# for the database field.
 
-		if hex_re.match(value) is None:
+		if hex_re.match(value) is None or len(value) > 200:
 			raise ValidationError("Registration ID (device token) is invalid")
 
 		return value

--- a/tests/test_rest_framework.py
+++ b/tests/test_rest_framework.py
@@ -45,6 +45,14 @@ class APNSDeviceSerializerTestCase(TestCase):
 		})
 		self.assertTrue(serializer.is_valid())
 
+		# valid data - 80 bytes lower case
+		serializer = APNSDeviceSerializer(data={
+			"registration_id": "ae" * 80,
+			"name": "Apple iPhone 14+",
+			"device_id": "ffffffffffffffffffffffffffffffff",
+		})
+		self.assertTrue(serializer.is_valid())
+
 		# invalid data - device_id, registration_id
 		serializer = APNSDeviceSerializer(data={
 			"registration_id": "invalid device token contains no hex",


### PR DESCRIPTION
# PR-Summary

According to [Apple Docs](https://developer.apple.com/documentation/uikit/uiapplicationdelegate/1622958-application) "APNs device tokens are of variable length. Do not hard-code their size."

<details>
<summary>Changelog</summary>

> - Modified `APNDeviceSerializer` to skip fixed-length token validation.
> - Added Test for a variable length.

</details>
